### PR TITLE
Issue-139. fix: improve S3 credential handling, add artifact disable …

### DIFF
--- a/java-reporter-core/pom.xml
+++ b/java-reporter-core/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>java-reporter-core</artifactId>
-    <version>0.16.0</version>
+    <version>0.16.1</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Reporter Core</name>

--- a/java-reporter-core/src/main/java/io/testomat/core/client/TestomatioClient.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/client/TestomatioClient.java
@@ -1,5 +1,6 @@
 package io.testomat.core.client;
 
+import static io.testomat.core.constants.ArtifactPropertyNames.ARTIFACT_DISABLE_PROPERTY_NAME;
 import static io.testomat.core.constants.ArtifactPropertyNames.JSONL_PATH_PROPERTY_NAME;
 import static io.testomat.core.constants.CommonConstants.RESPONSE_UID_KEY;
 
@@ -23,7 +24,6 @@ import io.testomat.core.model.TestResult;
 import io.testomat.core.propertyconfig.impl.PropertyProviderFactoryImpl;
 import io.testomat.core.propertyconfig.interf.PropertyProvider;
 import io.testomat.core.runmanager.GlobalRunManager;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -84,7 +84,7 @@ public class TestomatioClient implements ApiInterface {
             throw new RunCreationFailedException(
                     "Invalid response: missing UID in create test run response");
         }
-        if (responseBody.containsKey("artifacts")) {
+        if (responseBody.containsKey("artifacts") && !isArtifactDisabled()) {
             Map<String, Object> creds = (Map<String, Object>) responseBody.get("artifacts");
             credentialsManager.populateCredentials(creds);
             credentialsValidationService.areCredentialsValid(CredentialsManager.getCredentials());
@@ -200,6 +200,14 @@ public class TestomatioClient implements ApiInterface {
             client.post(url, requestBody, null);
         } catch (IOException e) {
             throw new ArtifactManagementException("Failed to upload artifact links to Testomatio", e);
+        }
+    }
+
+    private boolean isArtifactDisabled() {
+        try {
+            return Boolean.parseBoolean(provider.getProperty(ARTIFACT_DISABLE_PROPERTY_NAME));
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/java-reporter-core/src/main/java/io/testomat/core/constants/ArtifactPropertyNames.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/constants/ArtifactPropertyNames.java
@@ -8,6 +8,7 @@ public class ArtifactPropertyNames {
     public static final String ENDPOINT_PROPERTY_NAME = "s3.endpoint";
     public static final String ASSUME_ROLE_ARN_PROPERTY_NAME = "s3.assume.role.arn";
     public static final String ASSUME_ROLE_EXTERNAL_ID_PROPERTY_NAME = "s3.assume.role.external.id";
+    public static final String SESSION_TOKEN_PROPERTY_NAME = "s3.session-token";
 
     public static final String FORCE_PATH_PROPERTY_NAME = "s3.force-path-style";
 

--- a/java-reporter-core/src/main/java/io/testomat/core/constants/CommonConstants.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/constants/CommonConstants.java
@@ -1,7 +1,7 @@
 package io.testomat.core.constants;
 
 public class CommonConstants {
-    public static final String REPORTER_VERSION = "0.16.0";
+    public static final String REPORTER_VERSION = "0.16.1";
 
     public static final String TESTS_STRING = "tests";
     public static final String API_KEY_STRING = "api_key";

--- a/java-reporter-core/src/main/java/io/testomat/core/constants/CredentialConstants.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/constants/CredentialConstants.java
@@ -12,6 +12,7 @@ public class CredentialConstants {
     public static final String ARN = "ARN";
     public static final String ENDPOINT = "ENDPOINT";
     public static final String FORCE_PATH = "FORCE_PATH_STYLE";
+    public static final String SESSION_TOKEN = "SESSION_TOKEN";
 
     private CredentialConstants() {
     }

--- a/java-reporter-core/src/main/java/io/testomat/core/constants/PropertyValuesConstants.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/constants/PropertyValuesConstants.java
@@ -5,5 +5,5 @@ public class PropertyValuesConstants {
     public static final int DEFAULT_FLUSH_INTERVAL_SECONDS = 10;
     public static final String DEFAULT_URL = "https://app.testomat.io/";
     public static final String DEFAULT_RUN_TITLE = "Default Run Title";
-    public static final String DEFAULT_JSONL_PATH = "target/testomat/testomat-artifacts.json";
+    public static final String DEFAULT_JSONL_PATH = "testomat/testomat-artifacts.json";
 }

--- a/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/client/S3ClientFactory.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/client/S3ClientFactory.java
@@ -5,6 +5,8 @@ import io.testomat.core.facade.methods.artifact.credential.S3Credentials;
 import java.net.URI;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -14,30 +16,20 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 /**
- * Factory for creating configured S3Client instances with custom endpoint support. Handles AWS credentials, regions,
- * and S3-compatible storage configurations.
+ * Factory for creating configured S3Client instances.
  */
 public class S3ClientFactory {
 
     /**
-     * Creates a configured S3Client based on current credentials and settings.
-     * Priority:
-     * 1. IAM Role (if roleArn configured);
-     * 2. Static access key / secret key.
-     *
-     * @return configured S3Client instance
-     * @throws IllegalArgumentException if credentials are invalid or missing
+     * Creates configured S3 client.
      */
     public S3Client createS3Client() {
         S3Credentials s3 = CredentialsManager.getCredentials();
 
         Region region = resolveRegion(s3);
 
-        AwsCredentialsProvider provider =
-            buildCredentialsProvider(s3, region);
-
         S3ClientBuilder builder = S3Client.builder()
-            .credentialsProvider(provider)
+            .credentialsProvider(buildCredentialsProvider(s3, region))
             .region(region);
 
         configureEndpoint(builder, s3);
@@ -46,62 +38,66 @@ public class S3ClientFactory {
     }
 
     /**
-     * Builds AWS credentials provider.
+     * Creates credentials provider.
+     *
+     * Supports:
+     * - AccessKey + SecretKey
+     * - AccessKey + SecretKey + SessionToken
+     * - IAM role assumption via STS (isIam + roleArn)
      */
     private AwsCredentialsProvider buildCredentialsProvider(S3Credentials s3, Region region) {
-        boolean useIamRole = s3.isIam() && s3.getRoleArn() != null && !s3.getRoleArn().isBlank();
 
-        if (useIamRole) {
-            return buildIamRoleProvider(s3, region);
+        if (!isBlank(s3.getAccessKeyId()) && !isBlank(s3.getSecretAccessKey()) && !isBlank(s3.getSessionToken())) {
+            return StaticCredentialsProvider.create(
+                AwsSessionCredentials.create(
+                    s3.getAccessKeyId().trim(),
+                    s3.getSecretAccessKey().trim(),
+                    s3.getSessionToken().trim()
+                )
+            );
         }
 
-        return buildStaticCredentialsProvider(s3);
+        if (s3.isIam() && !isBlank(s3.getRoleArn())) {
+            AwsCredentialsProvider baseProvider = buildBaseProvider(s3);
+            StsClient stsClient = StsClient.builder()
+                .credentialsProvider(baseProvider)
+                .region(region)
+                .build();
+
+            return StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(r -> {
+                    r.roleArn(s3.getRoleArn().trim());
+                    r.roleSessionName("testomat-s3-session");
+                    if (!isBlank(s3.getExternalId())) {
+                        r.externalId(s3.getExternalId().trim());
+                    }
+                })
+                .build();
+        }
+
+        return buildBaseProvider(s3);
     }
 
-    /**
-     * Creates AssumeRole credentials provider.
-     */
-    private AwsCredentialsProvider buildIamRoleProvider(S3Credentials s3Credentials, Region region) {
-        AwsCredentialsProvider baseCredentials = buildStaticCredentialsProvider(s3Credentials);
-
-        StsClient stsClient = StsClient.builder()
-            .region(region)
-            .credentialsProvider(baseCredentials)
-            .build();
-
-        return StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(stsClient)
-            .refreshRequest(request -> {
-                request.roleArn(s3Credentials.getRoleArn().trim());
-                request.roleSessionName("testomat-s3-upload");
-
-                if (s3Credentials.getExternalId() != null
-                    && !s3Credentials.getExternalId().isBlank()) {
-
-                    request.externalId(s3Credentials.getExternalId().trim());
-                }
-            })
-            .build();
-    }
-
-    /**
-     * Creates static credentials provider.
-     */
-    private AwsCredentialsProvider buildStaticCredentialsProvider(S3Credentials s3Credentials) {
-        if (s3Credentials.getAccessKeyId() == null || s3Credentials.getAccessKeyId().isBlank()) {
-            throw new IllegalArgumentException("AWS access key is missing");
+    private AwsCredentialsProvider buildBaseProvider(S3Credentials s3) {
+        if (!isBlank(s3.getAccessKeyId()) && !isBlank(s3.getSecretAccessKey())) {
+            if (!isBlank(s3.getSessionToken())) {
+                return StaticCredentialsProvider.create(
+                    AwsSessionCredentials.create(
+                        s3.getAccessKeyId().trim(),
+                        s3.getSecretAccessKey().trim(),
+                        s3.getSessionToken().trim()
+                    )
+                );
+            }
+            return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                    s3.getAccessKeyId().trim(),
+                    s3.getSecretAccessKey().trim()
+                )
+            );
         }
-
-        if (s3Credentials.getSecretAccessKey() == null || s3Credentials.getSecretAccessKey().isBlank()) {
-            throw new IllegalArgumentException("AWS secret key is missing");
-        }
-
-        AwsBasicCredentials credentials =
-            AwsBasicCredentials.create(
-                s3Credentials.getAccessKeyId().trim(),
-                s3Credentials.getSecretAccessKey().trim());
-
-        return StaticCredentialsProvider.create(credentials);
+        return DefaultCredentialsProvider.create();
     }
 
     /**
@@ -109,21 +105,22 @@ public class S3ClientFactory {
      */
     private Region resolveRegion(S3Credentials s3Credentials) {
         try {
-            if (s3Credentials.getRegion() == null || s3Credentials.getRegion().isBlank()) {
+            if (isBlank(s3Credentials.getRegion())) {
                 return Region.US_EAST_1;
             }
+
             return Region.of(s3Credentials.getRegion().trim());
+
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid AWS region: " + s3Credentials.getRegion(), e);
         }
     }
 
     /**
-     * Configures custom endpoint and path-style access.
+     * Configures endpoint and path style access.
      */
     private void configureEndpoint(S3ClientBuilder builder, S3Credentials s3Credentials) {
-        boolean hasCustomEndpoint =
-            s3Credentials.getCustomEndpoint() != null && !s3Credentials.getCustomEndpoint().isBlank();
+        boolean hasCustomEndpoint = !isBlank(s3Credentials.getCustomEndpoint());
 
         if (hasCustomEndpoint) {
             try {
@@ -136,11 +133,12 @@ public class S3ClientFactory {
         if (s3Credentials.isForcePath() || hasCustomEndpoint) {
             builder.serviceConfiguration(
                 S3Configuration.builder()
-                    .pathStyleAccessEnabled(
-                        s3Credentials.isForcePath()
-                    )
-                    .build()
-            );
+                    .pathStyleAccessEnabled(s3Credentials.isForcePath())
+                    .build());
         }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/credential/CredentialsManager.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/credential/CredentialsManager.java
@@ -9,6 +9,7 @@ import static io.testomat.core.constants.ArtifactPropertyNames.FORCE_PATH_PROPER
 import static io.testomat.core.constants.ArtifactPropertyNames.PRIVATE_ARTIFACTS_PROPERTY_NAME;
 import static io.testomat.core.constants.ArtifactPropertyNames.REGION_PROPERTY_NAME;
 import static io.testomat.core.constants.ArtifactPropertyNames.SECRET_ACCESS_KEY_PROPERTY_NAME;
+import static io.testomat.core.constants.ArtifactPropertyNames.SESSION_TOKEN_PROPERTY_NAME;
 import static io.testomat.core.constants.CredentialConstants.ACCESS_KEY_ID;
 import static io.testomat.core.constants.CredentialConstants.ARN;
 import static io.testomat.core.constants.CredentialConstants.BUCKET;
@@ -19,6 +20,7 @@ import static io.testomat.core.constants.CredentialConstants.IAM;
 import static io.testomat.core.constants.CredentialConstants.PRESIGN;
 import static io.testomat.core.constants.CredentialConstants.REGION;
 import static io.testomat.core.constants.CredentialConstants.SECRET_ACCESS_KEY;
+import static io.testomat.core.constants.CredentialConstants.SESSION_TOKEN;
 import static io.testomat.core.constants.CredentialConstants.SHARED;
 
 import io.testomat.core.propertyconfig.impl.PropertyProviderFactoryImpl;
@@ -75,6 +77,9 @@ public class CredentialsManager {
         populateCredentialField(ACCESS_KEY_PROPERTY_NAME, ACCESS_KEY_ID, credsFromServer, "AccessKey",
                 value -> credentials.setAccessKeyId(getStringValue(value)));
 
+        populateCredentialField(SESSION_TOKEN_PROPERTY_NAME, SESSION_TOKEN, credsFromServer, "SessionToken",
+                value -> credentials.setSessionToken(getStringValue(value)));
+
         populateCredentialField(BUCKET_PROPERTY_NAME, BUCKET, credsFromServer, "Bucket",
                 value -> credentials.setBucket(getStringValue(value)));
 
@@ -89,6 +94,12 @@ public class CredentialsManager {
 
         credentials.setIam(getBooleanValue(credsFromServer.get(IAM)));
         credentials.setShared(getBooleanValue(credsFromServer.get(SHARED)));
+
+        if (getPropertyFromEnv(ACCESS_KEY_PROPERTY_NAME) != null
+                || getPropertyFromEnv(SECRET_ACCESS_KEY_PROPERTY_NAME) != null) {
+            credentials.setSessionToken(null);
+            log.debug("SessionToken cleared because access/secret keys were overridden by env");
+        }
 
         logCredentialsInitializationResult();
     }

--- a/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/credential/S3Credentials.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/facade/methods/artifact/credential/S3Credentials.java
@@ -16,6 +16,7 @@ public class S3Credentials {
     private String roleArn;
     private String externalId;
     private boolean forcePath = false;
+    private String sessionToken;
 
     public boolean isForcePath() {
         return forcePath;
@@ -103,5 +104,13 @@ public class S3Credentials {
 
     public void setRoleArn(String roleArn) {
         this.roleArn = roleArn;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public void setSessionToken(String sessionToken) {
+        this.sessionToken = sessionToken;
     }
 }

--- a/java-reporter-core/src/main/java/io/testomat/core/propertyconfig/util/DefaultPropertiesStorage.java
+++ b/java-reporter-core/src/main/java/io/testomat/core/propertyconfig/util/DefaultPropertiesStorage.java
@@ -7,6 +7,8 @@ import static io.testomat.core.constants.PropertyValuesConstants.DEFAULT_JSONL_P
 import static io.testomat.core.constants.PropertyValuesConstants.DEFAULT_RUN_TITLE;
 import static io.testomat.core.constants.PropertyValuesConstants.DEFAULT_URL;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -28,10 +30,18 @@ public class DefaultPropertiesStorage {
     public static final Map<String, String> DEFAULTS;
 
     static {
+        String jsonlPath = String.format("target/%s", DEFAULT_JSONL_PATH);
+        String userDir = System.getProperty("user.dir");
+        if (userDir != null) {
+            if (Files.exists(Paths.get(userDir, "build.gradle"))
+                    || Files.exists(Paths.get(userDir, "build.gradle.kts"))) {
+                jsonlPath = String.format("build/%s", DEFAULT_JSONL_PATH);
+            }
+        }
         DEFAULTS = Map.of(
                 HOST_URL_PROPERTY_NAME, DEFAULT_URL,
                 RUN_TITLE_PROPERTY_NAME, DEFAULT_RUN_TITLE,
-                JSONL_PATH_PROPERTY_NAME, DEFAULT_JSONL_PATH
+                JSONL_PATH_PROPERTY_NAME, jsonlPath
             );
     }
 }

--- a/java-reporter-core/src/test/java/io/testomat/core/artifact/client/S3ClientFactoryTest.java
+++ b/java-reporter-core/src/test/java/io/testomat/core/artifact/client/S3ClientFactoryTest.java
@@ -9,7 +9,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -27,98 +30,66 @@ class S3ClientFactoryTest {
     @Test
     void shouldReturnDefaultRegionWhenRegionIsBlank() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getRegion()).thenReturn(" ");
-
-        Region region = invokeResolveRegion(s3);
-
-        assertEquals(Region.US_EAST_1, region);
+        assertEquals(Region.US_EAST_1, invokeResolveRegion(s3));
     }
 
     @Test
     void shouldReturnProvidedRegion() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getRegion()).thenReturn("eu-central-1");
-
-        Region region = invokeResolveRegion(s3);
-
-        assertEquals(Region.EU_CENTRAL_1, region);
+        assertEquals(Region.EU_CENTRAL_1, invokeResolveRegion(s3));
     }
 
     @Test
-    void shouldCreateStaticCredentialsProvider() throws Exception {
+    void shouldCreateBasicCredentials() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getAccessKeyId()).thenReturn("access-key");
         when(s3.getSecretAccessKey()).thenReturn("secret-key");
 
-        AwsCredentialsProvider provider =
-            invokeBuildStaticCredentialsProvider(s3);
-
-        assertNotNull(provider);
+        AwsCredentialsProvider provider = invokeBuildBaseProvider(s3);
         assertInstanceOf(StaticCredentialsProvider.class, provider);
+        AwsBasicCredentials creds = (AwsBasicCredentials) provider.resolveCredentials();
+        assertEquals("access-key", creds.accessKeyId());
+        assertEquals("secret-key", creds.secretAccessKey());
     }
 
     @Test
-    void shouldTrimStaticCredentials() throws Exception {
+    void shouldTrimBasicCredentials() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getAccessKeyId()).thenReturn("  access-key  ");
         when(s3.getSecretAccessKey()).thenReturn("  secret-key  ");
 
-        StaticCredentialsProvider provider =
-            (StaticCredentialsProvider) invokeBuildStaticCredentialsProvider(s3);
-
-        assertEquals(
-            "access-key",
-            provider.resolveCredentials().accessKeyId()
-        );
-
-        assertEquals(
-            "secret-key",
-            provider.resolveCredentials().secretAccessKey()
-        );
+        StaticCredentialsProvider provider = (StaticCredentialsProvider) invokeBuildBaseProvider(s3);
+        assertEquals("access-key", provider.resolveCredentials().accessKeyId());
+        assertEquals("secret-key", provider.resolveCredentials().secretAccessKey());
     }
 
     @Test
-    void shouldThrowExceptionWhenAccessKeyMissing() {
+    void shouldCreateSessionCredentials() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
-        when(s3.getAccessKeyId()).thenReturn(" ");
+        when(s3.getAccessKeyId()).thenReturn("ASIAkey");
         when(s3.getSecretAccessKey()).thenReturn("secret");
+        when(s3.getSessionToken()).thenReturn("token");
 
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> invokeBuildStaticCredentialsProvider(s3)
-        );
-
-        assertEquals("AWS access key is missing", exception.getMessage());
+        StaticCredentialsProvider provider = (StaticCredentialsProvider) invokeBuildBaseProvider(s3);
+        assertInstanceOf(AwsSessionCredentials.class, provider.resolveCredentials());
+        AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
+        assertEquals("ASIAkey", creds.accessKeyId());
+        assertEquals("token", creds.sessionToken());
     }
 
     @Test
-    void shouldThrowExceptionWhenSecretKeyMissing() {
+    void shouldFallbackToDefaultProviderWhenNoKeys() throws Exception {
         S3Credentials s3 = mock(S3Credentials.class);
-
-        when(s3.getAccessKeyId()).thenReturn("access");
-        when(s3.getSecretAccessKey()).thenReturn(" ");
-
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> invokeBuildStaticCredentialsProvider(s3)
-        );
-
-        assertEquals("AWS secret key is missing", exception.getMessage());
+        assertInstanceOf(DefaultCredentialsProvider.class, invokeBuildBaseProvider(s3));
     }
 
     @Test
     void shouldConfigureCustomEndpoint() throws Exception {
         S3ClientBuilder builder = mock(S3ClientBuilder.class, RETURNS_SELF);
         S3Credentials s3 = mock(S3Credentials.class);
-
-        when(s3.getCustomEndpoint())
-            .thenReturn("http://localhost:9000");
-
+        when(s3.getCustomEndpoint()).thenReturn("http://localhost:9000");
         when(s3.isForcePath()).thenReturn(false);
 
         invokeConfigureEndpoint(builder, s3);
@@ -131,7 +102,6 @@ class S3ClientFactoryTest {
     void shouldConfigurePathStyleWhenForcePathEnabled() throws Exception {
         S3ClientBuilder builder = mock(S3ClientBuilder.class, RETURNS_SELF);
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getCustomEndpoint()).thenReturn(null);
         when(s3.isForcePath()).thenReturn(true);
 
@@ -144,25 +114,19 @@ class S3ClientFactoryTest {
     void shouldThrowExceptionForInvalidEndpoint() {
         S3ClientBuilder builder = mock(S3ClientBuilder.class, RETURNS_SELF);
         S3Credentials s3 = mock(S3Credentials.class);
-
         when(s3.getCustomEndpoint()).thenReturn("invalid-url%%%");
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
             () -> invokeConfigureEndpoint(builder, s3)
         );
-
         assertTrue(exception.getMessage().contains("Invalid endpoint URL"));
     }
 
     private Region invokeResolveRegion(S3Credentials s3) throws Exception {
         Method method = S3ClientFactory.class.getDeclaredMethod(
-            "resolveRegion",
-            S3Credentials.class
-        );
-
+            "resolveRegion", S3Credentials.class);
         method.setAccessible(true);
-
         try {
             return (Region) method.invoke(factory, s3);
         } catch (InvocationTargetException e) {
@@ -170,17 +134,10 @@ class S3ClientFactoryTest {
         }
     }
 
-    private AwsCredentialsProvider invokeBuildStaticCredentialsProvider(
-        S3Credentials s3
-    ) throws Exception {
-
+    private AwsCredentialsProvider invokeBuildBaseProvider(S3Credentials s3) throws Exception {
         Method method = S3ClientFactory.class.getDeclaredMethod(
-            "buildStaticCredentialsProvider",
-            S3Credentials.class
-        );
-
+            "buildBaseProvider", S3Credentials.class);
         method.setAccessible(true);
-
         try {
             return (AwsCredentialsProvider) method.invoke(factory, s3);
         } catch (InvocationTargetException e) {
@@ -189,18 +146,11 @@ class S3ClientFactoryTest {
     }
 
     private void invokeConfigureEndpoint(
-        S3ClientBuilder builder,
-        S3Credentials s3
+        S3ClientBuilder builder, S3Credentials s3
     ) throws Exception {
-
         Method method = S3ClientFactory.class.getDeclaredMethod(
-            "configureEndpoint",
-            S3ClientBuilder.class,
-            S3Credentials.class
-        );
-
+            "configureEndpoint", S3ClientBuilder.class, S3Credentials.class);
         method.setAccessible(true);
-
         try {
             method.invoke(factory, builder, s3);
         } catch (InvocationTargetException e) {

--- a/java-reporter-cucumber/pom.xml
+++ b/java-reporter-cucumber/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>java-reporter-cucumber</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Java Reporter Cucumber</name>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.testomat</groupId>
             <artifactId>java-reporter-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java-reporter-junit/pom.xml
+++ b/java-reporter-junit/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>java-reporter-junit</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Java Reporter JUnit</name>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.testomat</groupId>
             <artifactId>java-reporter-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java-reporter-karate/pom.xml
+++ b/java-reporter-karate/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>java-reporter-karate</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Java Reporter Karate</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.testomat</groupId>
             <artifactId>java-reporter-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>io.karatelabs</groupId>

--- a/java-reporter-testng/pom.xml
+++ b/java-reporter-testng/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>java-reporter-testng</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Java Reporter TestNG</name>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.testomat</groupId>
             <artifactId>java-reporter-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/testomat-allure-adapter/pom.xml
+++ b/testomat-allure-adapter/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.testomat</groupId>
     <artifactId>testomat-allure-adapter</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <packaging>jar</packaging>
 
     <name>Testomat.io Testomat Allure adapter</name>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.testomat</groupId>
             <artifactId>java-reporter-core</artifactId>
-            <version>0.16.0</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>io.qameta.allure</groupId>


### PR DESCRIPTION
- Support STS AssumeRole when iam=true + roleArn
- Fix sessionToken not populated from server response
- Clear sessionToken when keys overridden via env
- Skip credential validation when testomatio.artifact.disable=true
- Detect Gradle vs Maven for default JSONL path (build/ vs target/)